### PR TITLE
fix prerelease

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -11,22 +11,35 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version-file: 'go.mod'
+          go-version-file: go.mod
           cache: true
-      - run: make build
+      - run: make release
       - run: make test
       - uses: golangci/golangci-lint-action@v3
         with:
           # setup-go handles pkg cache
           skip-pkg-cache: true
           skip-build-cache: true
-      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: binaries
+          path: dist/*
+
+  prerelease:
+    if: github.event.pull_request.merged == true
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        name: binaries
+      - uses: marvinpinto/action-automatic-releases@v1.2.1
         if: github.event.pull_request.merged == true
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest"
+          automatic_release_tag: latest
           prerelease: true
-          title: "Development Build"
+          title: Development Build
           files: |
             dist/*
             LICENSE

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 BUILD_DIR=./cmd/...
 
-.PHONY: build test release.arm64 release.armv7 release.amd64
+.PHONY: build test release.arm64 release.armv7 release.amd64 verify
 
-build:
+verify:
 	go mod verify
+
+build: verify
 	go build -o dist/ $(BUILD_FLAGS) $(BUILD_DIR)
 
 release.arm64:
@@ -16,7 +18,7 @@ release.amd64:
 	GOOS=linux GOARCH=amd64 go build -o dist/linux-amd64/ $(BUILD_FLAGS) $(BUILD_DIR)
 	
 
-release: release.arm64 release.armv7 release.amd64
+release: verify release.arm64 release.armv7 release.amd64
 
 test:
 	go test -v -race ./...


### PR DESCRIPTION
We want per-arch binaries, not the default. Try using another job to organize.