### PR TITLE
Add a idle timeout to bluetooth scanning

### DIFF
--- a/pkg/scanner/idle/idle.go
+++ b/pkg/scanner/idle/idle.go
@@ -1,0 +1,56 @@
+package idle
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+var ErrTimedOut = errors.New("timed out due to no activity")
+
+// IdleTimer is a dead-mans switch to detect inactivity. Create with New.
+type IdleTimer struct {
+	timeout    time.Duration
+	done       chan struct{}
+	lastActive time.Time
+	mu         sync.RWMutex // protects lastActive
+}
+
+// New creates an IdleTimer that will return errors if the there is no activity
+// seen for the given duration.
+func New(d time.Duration) *IdleTimer {
+	return &IdleTimer{
+		timeout: d,
+		done:    make(chan struct{}),
+	}
+}
+
+// SetActive marks this timer as still active.
+func (t *IdleTimer) SetActive() {
+	t.mu.Lock()
+	t.lastActive = time.Now()
+	t.mu.Unlock()
+}
+
+// Run runs until the context is cancelled or no-one calls SetActive for more
+// than the timer's duration. Always returns an error, either the context's or
+// ErrTimedOut.
+func (t *IdleTimer) Run(ctx context.Context) error {
+	ticker := time.NewTicker(t.timeout)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case now := <-ticker.C:
+			tooOld := now.Add(-t.timeout)
+			t.mu.RLock()
+			isIdle := t.lastActive.Before(tooOld)
+			t.mu.RUnlock()
+			if isIdle {
+				return ErrTimedOut
+			}
+		}
+	}
+}

--- a/pkg/scanner/idle/idle_test.go
+++ b/pkg/scanner/idle/idle_test.go
@@ -1,0 +1,45 @@
+package idle_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/lazy-electron-consulting/victron-bluetooth/pkg/scanner/idle"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimer_Idle(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	d := 10 * time.Millisecond
+	timer := idle.New(d)
+
+	go func() {
+		<-time.After(2 * d)
+		cancel()
+	}()
+
+	err := timer.Run(ctx)
+	require.ErrorIs(t, err, idle.ErrTimedOut)
+}
+
+func TestTimer_Active(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	d := 100 * time.Millisecond
+	timer := idle.New(d)
+
+	go func() {
+		defer cancel()
+		timer.SetActive()
+		<-time.After(50 * time.Millisecond)
+		timer.SetActive()
+		<-time.After(50 * time.Millisecond)
+		timer.SetActive()
+		<-time.After(50 * time.Millisecond)
+	}()
+
+	err := timer.Run(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}


### PR DESCRIPTION
I keep getting hangs where the bluetooth just stops scanning. Detect it and stop the process.

There might be something smarter to do to recover without stopping the world, but this will be a good start.